### PR TITLE
Make compatible with JS strict mode

### DIFF
--- a/src/xml2js.coffee
+++ b/src/xml2js.coffee
@@ -155,11 +155,11 @@ class exports.Builder
                 else
                   element = element.ele(key, entry).up()
               else
-                element = arguments.callee(element.ele(key), entry).up()
+                element = render(element.ele(key), entry).up()
 
           # Case #4 Objects
           else if typeof child is "object"
-            element = arguments.callee(element.ele(key), child).up()
+            element = render(element.ele(key), child).up()
 
           # Case #5 String and remaining types
           else


### PR DESCRIPTION
Unfortunately, "arguments.callee" does not work with strict mode which will be globally enabled on many node and io.js instances soon because it enables ES6 features.

io.js has a flag (--use-strict) for that purpose which we are using and which has caused compatibility issues with xml2js.
